### PR TITLE
update template installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ curl -L https://raw.githubusercontent.com/DuendeSoftware/IdentityServer.Quicksta
 Or you can use our [templates](https://github.com/DuendeSoftware/IdentityServer.Templates) (which will include solution and project files):
 
 ```
-dotnet new -i Duende.IdentityServer.Templates
+dotnet new install Duende.IdentityServer.Templates
 dotnet new isaspid
 ```
 


### PR DESCRIPTION
When using the command to install the templates, a warning was given as follows:
`Warning: use of 'dotnet new --install' is deprecated. Use 'dotnet new install' instead.`

This commit fixes it and uses the updated command for template installation.